### PR TITLE
Fix ping DO dev smoke route

### DIFF
--- a/.cursor/skills/cf-starter-gotchas/SKILL.md
+++ b/.cursor/skills/cf-starter-gotchas/SKILL.md
@@ -35,6 +35,10 @@ These trip up new contributors and agents most often. For commands and checklist
 
 14. **New Durable Object / worker package** — Use `import type { CloudflareEnv }` and `new Hono<{ Bindings: CloudflareEnv }>()` in DO workers so `c.env` is typed. Shared RPC types in `workers/rpc.ts` (no `import` from `../env` there); add `package.json#exports` `"./workers/rpc"` when needed. `WorkerRef` / cross-worker: one `workspace:*` direction; the other side uses a relative `../<pkg>/workers/rpc` import to avoid Turbo cycles. New Alchemy apps: root [package.json](../../../package.json) `dev` filter, [turbo.json](../../../turbo.json) `<pkg>#destroy` with `dependsOn: ["cf-starter-web#destroy"]`. **Do not** add another package’s `workers/app.ts` to [tsconfig.cloudflare.json](../../../apps/web/tsconfig.cloudflare.json) `include`—it can break `cf-starter-web`’s `Env`. Step-by-step: [cf-durable-object-package/SKILL.md](../cf-durable-object-package/SKILL.md), [cf-web-alchemy-bindings/SKILL.md](../cf-web-alchemy-bindings/SKILL.md), [cf-worker-rpc-turbo/SKILL.md](../cf-worker-rpc-turbo/SKILL.md).
 
+15. **Durable Object RPC `using` in local dev** — `@firtoz/hono-fetcher` types real DO HTTP results as disposable when Workers RPC attaches `[Symbol.dispose]`, but Vite SSR / some Miniflare paths may return plain `Response` objects. If `using res = await api.get(...)` throws `Symbol(Symbol.dispose) is not a function`, use `const res = await api.get(...)` in that local route or guard disposer calls. `using api = honoDoFetcherWithName(...)` is safer because the library guards missing stub disposers.
+
+16. **Alchemy dev stale web process state** — If `bun run dev` prints `webUrl: "http://localhost:5173/"` but port 5173 is closed after a web crash, check generated Alchemy state. Remove `.alchemy/pids/cf-starter-web.pid.json` and `.alchemy/web/local/cf-starter-web.json`, ensure `.alchemy/logs/cf-starter-web.log` exists (create an empty file if needed), then restart `bun run dev`. Do not commit `.alchemy/` files.
+
 ## Also load
 
 - [.cursor/rules/cf-workers-patterns.mdc](../../rules/cf-workers-patterns.mdc) — short always-on reminder for workers, env, routes.

--- a/.cursor/skills/cf-starter-workflow/SKILL.md
+++ b/.cursor/skills/cf-starter-workflow/SKILL.md
@@ -66,7 +66,7 @@ Access in app code: `import { env } from "cloudflare:workers"` only.
 
 **Deploy / secrets:** `bun run deploy` → **`turbo run deploy --filter=cf-starter-web`** (pulls dependent worker deploys). `alchemyPassword` in [cf-starter-alchemy](../../../packages/cf-starter-alchemy) requires **`ALCHEMY_PASSWORD`**. Run **`bun run setup`** in a terminal for a confirmation prompt, or **`bun run setup -- --yes`** / **`bun packages/scripts/setup-env.ts --yes`** in automation. [Alchemy — encryption password](https://alchemy.run/concepts/secret/#encryption-password), [Getting Started](https://alchemy.run/getting-started/) for `CLOUDFLARE_API_TOKEN`.
 
-- **Local dev** — `bun run dev` runs a filtered `turbo run dev` (web + worker apps), each with `alchemy dev --app …` per [Alchemy monorepo](https://alchemy.run/guides/turborepo/).
+- **Local dev** — `bun run dev` runs a filtered `turbo run dev` (web + worker apps), each with `alchemy dev --app …` per [Alchemy monorepo](https://alchemy.run/guides/turborepo/). When verifying setup, exercise `/`, `/visitors`, `/ping-do`, and `/chat`; this covers React Router SSR, D1, cross-script DO bindings, and chat WebSockets. If web prints `webUrl` but port 5173 is closed after a crash, remove the stale generated `.alchemy/pids/cf-starter-web.pid.json`; if you also remove `.alchemy/logs/cf-starter-web.log`, recreate it before restarting because Alchemy's idempotent log follower expects the file to exist.
 
 ## Completion checklist (before you stop)
 

--- a/apps/web/app/routes/ping-do.tsx
+++ b/apps/web/app/routes/ping-do.tsx
@@ -17,7 +17,7 @@ export function meta(_args: Route.MetaArgs) {
 type PingBody = { pong: boolean; id: string };
 
 export async function loader(_args: Route.LoaderArgs): Promise<MaybeError<PingBody>> {
-	const api = honoDoFetcherWithName(env.PingDo, "demo");
+	using api = honoDoFetcherWithName(env.PingDo, "demo");
 	const res = await api.get({ url: "/ping" });
 	if (!res.ok) {
 		return fail(`PingDo HTTP ${res.status}`);

--- a/apps/web/app/routes/ping-do.tsx
+++ b/apps/web/app/routes/ping-do.tsx
@@ -17,8 +17,8 @@ export function meta(_args: Route.MetaArgs) {
 type PingBody = { pong: boolean; id: string };
 
 export async function loader(_args: Route.LoaderArgs): Promise<MaybeError<PingBody>> {
-	using api = honoDoFetcherWithName(env.PingDo, "demo");
-	using res = await api.get({ url: "/ping" });
+	const api = honoDoFetcherWithName(env.PingDo, "demo");
+	const res = await api.get({ url: "/ping" });
 	if (!res.ok) {
 		return fail(`PingDo HTTP ${res.status}`);
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Fixes the `/ping-do` loader so the dev smoke route can call the Ping Durable Object without a runtime response-disposer error.
- Uses `using api = honoDoFetcherWithName(...)` so the DO fetcher/stub is disposed where the library can guard missing local disposers.
- Sets up and verifies the local development stack for the web app plus chatroom, ping, and other worker packages.
- Documents the local dev gotchas discovered during setup: DO RPC `using` behavior and stale Alchemy web process state.

### Walkthrough
[dev_environment_walkthrough.mp4](https://cursor.com/agents/bc-6ad8c821-766e-435b-8e36-1d96040d4fde/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_environment_walkthrough.mp4)

### Testing
- `bash ./.cursor/setup-agent.sh`
- `bun run typegen && bun run typecheck && bun run lint && bun run build`
- `bun run typecheck && bun run lint`
- `curl` route probe for `/ping-do` after switching to `using api`
- `bun run dev` in a tmux session
- `curl` route probes for `/`, `/visitors`, `/ping-do`, and `/chat`
- Browser walkthrough of home, D1 visitor counter, Ping Durable Object, and chat UI

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ad8c821-766e-435b-8e36-1d96040d4fde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ad8c821-766e-435b-8e36-1d96040d4fde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

