### PR TITLE
Fix ping DO dev smoke route

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -6,11 +6,10 @@ Configuration and rules for Cursor IDE and Cloud Agents.
 
 **Read first:** [rules/00-cloud-agent-mandatory.mdc](./rules/00-cloud-agent-mandatory.mdc)
 
-Setup runs via [`.cursor/environment.json`](./environment.json) (`install` → `bash ./.cursor/setup-agent.sh`). If it did not run: `cd /workspace && bash ./.cursor/setup-agent.sh && source ~/.bashrc`. More detail and troubleshooting: [cloud-agent-setup.mdc](./rules/cloud-agent-setup.mdc).
+Setup should run through Cursor's saved Cloud Agent environment with install command `bash ./.cursor/setup-agent.sh`. If it did not run: `cd /workspace && bash ./.cursor/setup-agent.sh && source ~/.bashrc`. More detail and troubleshooting: [cloud-agent-setup.mdc](./rules/cloud-agent-setup.mdc).
 
 ## Directory structure
 
-- **`environment.json`** — Cloud Agent runtime; see [Cursor docs](https://cursor.com/docs/cloud-agent#the-environmentjson-spec).
 - **`setup-agent.sh`** — Installs Bun and runs `bun install` at repo root.
 - **`rules/`** — Workspace rules (e.g. `00-cloud-agent-mandatory.mdc`, `cloud-agent-setup.mdc`, `dev-server.mdc`, `git-workflow.mdc`, `git-completion-reminder.mdc` points at git + mandatory docs).
 - **`skills/`** — Project-specific playbooks under `.cursor/skills/`.

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,3 +1,0 @@
-{
-	"install": "bash ./.cursor/setup-agent.sh"
-}

--- a/.cursor/rules/00-cloud-agent-mandatory.mdc
+++ b/.cursor/rules/00-cloud-agent-mandatory.mdc
@@ -6,14 +6,12 @@ alwaysApply: false
 
 Read this file first on a cloud agent VM. It is short on purpose.
 
-## Automatic setup via environment.json
+## Automatic setup via Cursor saved environment
 
-The environment is configured to run setup automatically via `.cursor/environment.json`:
+This repo no longer commits `.cursor/environment.json`, so Cursor Cloud Agents use the environment saved in Cursor. Configure the saved environment install command as:
 
-```json
-{
-  "install": "bash ./.cursor/setup-agent.sh"
-}
+```bash
+bash ./.cursor/setup-agent.sh
 ```
 
 This runs on VM startup, installing bun and all dependencies automatically.
@@ -96,7 +94,7 @@ Add learnings so the next agent doesn't face the same issues.
 - [ ] Currently in repo root: `pwd` shows `/workspace`
 - [ ] If bun not found: Run setup manually (see above)
 
-Setup should run automatically via `environment.json`, but verify before proceeding.
+Setup should run automatically via the Cursor saved environment, but verify before proceeding.
 
 ## Completing your work (Cloud Agents)
 

--- a/.cursor/rules/cloud-agent-setup.mdc
+++ b/.cursor/rules/cloud-agent-setup.mdc
@@ -6,7 +6,7 @@ alwaysApply: false
 
 Start with the startup checklist in [00-cloud-agent-mandatory.mdc](00-cloud-agent-mandatory.mdc). This file adds detail, troubleshooting, and command reference only.
 
-`environment.json` in this repo is minimal (see [`.cursor/environment.json`](../environment.json) — `install` runs `bash ./.cursor/setup-agent.sh` on the agent VM). Cursor may merge other fields; see [Cursor environment docs](https://cursor.com/docs/cloud-agent#the-environmentjson-spec).
+This repo does not commit `.cursor/environment.json`, so Cursor Cloud Agents use the saved environment configured in Cursor. That saved environment should run `bash ./.cursor/setup-agent.sh` as the install command. If setup did not run, execute the manual fallback below. See [Cursor environment docs](https://cursor.com/docs/cloud-agent#the-environmentjson-spec).
 
 ## If setup failed
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ If `bun` is missing in the agent environment:
 cd /workspace && bash ./.cursor/setup-agent.sh && source ~/.bashrc
 ```
 
-Setup is normally applied via `.cursor/environment.json`.
+Setup is normally applied by the saved Cursor Cloud Agent environment.
 
 ## One-liner defaults
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Fixes the `/ping-do` loader so the dev smoke route can call the Ping Durable Object without a runtime response-disposer error.
- Uses `using api = honoDoFetcherWithName(...)` so the DO fetcher/stub is disposed where the library can guard missing local disposers.
- Sets up and verifies the local development stack for the web app plus chatroom, ping, and other worker packages.
- Documents the local dev gotchas discovered during setup: DO RPC `using` behavior and stale Alchemy web process state.
- Removes the committed `.cursor/environment.json` override and updates Cursor setup docs to rely on the saved Cursor Cloud Agent environment running `bash ./.cursor/setup-agent.sh`.

### Walkthrough
[dev_environment_walkthrough.mp4](https://cursor.com/agents/bc-6ad8c821-766e-435b-8e36-1d96040d4fde/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_environment_walkthrough.mp4)

### Testing
- `bash ./.cursor/setup-agent.sh`
- `bun run typegen && bun run typecheck && bun run lint && bun run build`
- `bun run typecheck && bun run lint`
- `curl` route probe for `/ping-do` after switching to `using api`
- `bun run dev` in a tmux session
- `curl` route probes for `/`, `/visitors`, `/ping-do`, and `/chat`
- Browser walkthrough of home, D1 visitor counter, Ping Durable Object, and chat UI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ad8c821-766e-435b-8e36-1d96040d4fde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ad8c821-766e-435b-8e36-1d96040d4fde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

