### PR TITLE
fix(chatroom-do): stub auth worker before AUTH service binding

### DIFF
--- a/durable-objects/chatroom-do/alchemy.run.ts
+++ b/durable-objects/chatroom-do/alchemy.run.ts
@@ -1,5 +1,5 @@
 import alchemy from "alchemy";
-import { DurableObjectNamespace, Worker, WorkerRef } from "alchemy/cloudflare";
+import { DurableObjectNamespace, Worker, WorkerRef, WorkerStub } from "alchemy/cloudflare";
 import { requireAlchemyPassword, requireEnv } from "alchemy-utils";
 import { alchemyCiCloudStateStoreOptions } from "alchemy-utils/alchemy-cloud-state-store";
 import { resolveStageFromEnv } from "alchemy-utils/deployment-stage";
@@ -24,6 +24,11 @@ const chatroomInternalSecretRaw = requireEnv(
 const chatroomInternalSecret = alchemy.secret(chatroomInternalSecretRaw);
 
 const PEER_AUTH_SCRIPT_NAME = omitDefaultPhysicalWorkerScriptName(ALCHEMY_APP_IDS.auth, app.stage);
+
+await WorkerStub<AuthWorkerRpc>("auth-worker-service-stub", {
+	name: PEER_AUTH_SCRIPT_NAME,
+	url: false,
+});
 
 export const ChatroomDo = await DurableObjectNamespace<Rpc.DurableObjectBranded>(
 	"chatroom-do-ChatroomDo-class",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

PR preview deploy fails when `chatroom-do` uploads before `auth-worker` exists:

```
Service binding 'AUTH' references Worker 'starter-auth-worker-pr-22' which was not found.
```

Turbo runs `chatroom-do#deploy:preview` in parallel with `auth-worker#deploy:preview` because `chatroom-do` only depends on `@internal/auth-client` (not `auth-worker`) in its workspace graph. The AUTH binding uses a `WorkerRef` to the auth worker's physical script name, so Cloudflare requires that script to exist at upload time.

## Fix

Add a `WorkerStub<AuthWorkerRpc>` in `chatroom-do/alchemy.run.ts` before creating the chatroom worker — the same pattern already used for the cyclic `ping-do` ↔ `other-worker` peer bindings. The stub provisions the peer script name so the AUTH service binding is valid even when deploy tasks run concurrently; the real auth worker replaces the stub when its deploy completes.

## Verification

- `bun run typecheck` (includes `chatroom-do`) passes locally
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48728ed7-de3a-49f8-a01d-fd080f93210d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48728ed7-de3a-49f8-a01d-fd080f93210d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

