### PR TITLE
refactor(auth): decouple chat guest session from auth-client

### DIFF
--- a/.agents/skills/cf-auth-setup/SKILL.md
+++ b/.agents/skills/cf-auth-setup/SKILL.md
@@ -53,7 +53,7 @@ OAuth redirect URIs must match the resolved URL: `https://<host>/api/auth/callba
 
 - Better Auth **`anonymous()`** plugin on `auth-worker` (`user.isAnonymous`, synthetic email `*@<PRODUCT_PREFIX>.guest`).
 - Display names: **`unique-names-generator`** (adjective + animal, e.g. `Coastal-Falcon`) via `workers/auth-worker/src/guest-display-name.ts` — not a shared `"Guest"` label.
-- **`/chat` loader** calls `ensureChatSession` → `POST /api/auth/sign-in/anonymous` when logged out; sets session cookie on the document response.
+- **`/chat` loader** calls `ensureChatSession` from **`apps/web/app/lib/ensure-chat-session.ts`** → `POST /api/auth/sign-in/anonymous` when logged out; sets session cookie on the document response.
 - **Guest** sessions: capped at **7 days** (`GUEST_SESSION_SECONDS`, enforced in `databaseHooks.session`) with **`updateAge` 1 day** — each visit extends expiry; no visit for a week and the guest identity is gone.
 - **Signed-in** accounts: default **30 days** (`SIGNED_IN_SESSION_SECONDS` in `createAuth()`); guest upgrade / OAuth graduation extends active sessions to this duration.
 - **Guest upgrade** at **`/guest/upgrade`**: email (`POST /api/guest/upgrade/email`) or OAuth **`link-social`** promotes the **same** `user.id` (`isAnonymous: false`); chat history in DO SQLite stays attached without migration.
@@ -67,7 +67,7 @@ OAuth redirect URIs must match the resolved URL: `https://<host>/api/auth/callba
 
 - **`createAuthClient(env.AUTH, request)`** — browser-backed session + custom API. Returns `{ session, admin, profile, fetch }` with **`MaybeError`** on mutations.
 - **`createServiceAuthClient(env.AUTH, secret)`** — machine admin (`AUTH_ADMIN_SECRET`) for cron/automation without a browser session.
-- **`getSession` / `requireAdmin` / `ensureChatSession`** — also available on `auth.session.*` (Better Auth `/api/auth/*`).
+- **`getSession` / `requireAdmin`** on `auth.session.*` (Better Auth `/api/auth/*`). Chat guest bootstrap: **`ensureChatSession`** in the web app (`~/lib/ensure-chat-session`), not on `@internal/auth-client`.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Bindings and route wiring: [`apps/web/alchemy.run.ts`](apps/web/alchemy.run.ts),
 │   └── chatroom-do/
 ├── packages/
 │   ├── alchemy-utils/          # PRODUCT_PREFIX, app ids, alchemy-cli
-│   ├── auth-client/            # getSession, ensureChatSession, binding headers for AUTH.fetch
+│   ├── auth-client/            # getSession, createAuthClient, binding headers for AUTH.fetch
 │   ├── auth-db/                # Better Auth D1 schema + migrations
 │   ├── chat-contract/
 │   ├── db/                     # App D1 schema + Drizzle migrations (/visitors)

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -12,7 +12,7 @@ React Router 7 application deployed on Cloudflare Workers.
 
 **Durable Objects / services:** `auth-worker` (plain Worker under `workers/`), `chatroom-do` (WebSockets / Socka; `/chat` and `/api/ws/*`), optional `posthog-proxy`.
 
-**Packages:** `@internal/db` (app D1 for `/visitors`), `@internal/auth-db` + `@internal/auth-client` (sessions, `ensureChatSession`, admin helpers), `@internal/chat-contract` (Socka types + WS attestation headers).
+**Packages:** `@internal/db` (app D1 for `/visitors`), `@internal/auth-db` + `@internal/auth-client` (sessions, admin helpers), `@internal/chat-contract` (Socka types + WS attestation). Guest chat: `app/lib/ensure-chat-session.ts`.
 
 **How bindings work:** **`apps/web/alchemy.run.ts`** declares app bindings and imports worker/DO resources from dependency packages' `./alchemy` exports. Types: **`types/env.d.ts`** (`typeof web["Env"]`). After route edits, **`bun run typegen`** from the repo root.
 
@@ -20,7 +20,7 @@ React Router 7 application deployed on Cloudflare Workers.
 
 - Browser hits **`/api/auth/*`** on the web worker; it forwards to the **`AUTH`** service binding (`auth-worker`).
 - Public auth URL is computed at deploy/dev time (no dotfile key) — see [cf-auth-setup](../../.agents/skills/cf-auth-setup/SKILL.md).
-- **`/chat`** uses `ensureChatSession` from `@internal/auth-client` so guests get a Better Auth anonymous session (random display name, 7-day sliding expiry). Only this route forwards auth `Set-Cookie` to the browser.
+- **`/chat`** uses `ensureChatSession` from `app/lib/ensure-chat-session.ts` so guests get a Better Auth anonymous session (random display name, 7-day sliding expiry). Only this route forwards auth `Set-Cookie` to the browser.
 - WebSocket upgrades: web worker calls `env.AUTH.getSession`, then proxies the upgrade to chatroom-do with attested headers (see `@internal/chat-contract`). One `CHATROOM.fetch` per connection, not a separate resolve hop.
 - OAuth (Google/GitHub): [`docs/oauth-setup.md`](../../docs/oauth-setup.md).
 - Fork setup: [`.agents/skills/cf-auth-setup/SKILL.md`](../../.agents/skills/cf-auth-setup/SKILL.md).

--- a/apps/web/app/lib/chat-session-context.ts
+++ b/apps/web/app/lib/chat-session-context.ts
@@ -1,7 +1,7 @@
 import { env } from "cloudflare:workers";
-import type { EnsureChatSessionResult } from "@internal/auth-client";
-import { createAuthClient, ensureChatSession } from "@internal/auth-client";
+import { createAuthClient } from "@internal/auth-client";
 import { createContext, type RouterContextProvider } from "react-router";
+import { type EnsureChatSessionResult, ensureChatSession } from "./ensure-chat-session";
 import { routeAuthClientContext } from "./route-auth-client";
 import { setResolvedAuthSession } from "./route-context";
 

--- a/apps/web/app/lib/ensure-chat-session.ts
+++ b/apps/web/app/lib/ensure-chat-session.ts
@@ -1,8 +1,11 @@
-import { createBindingAuthWorkerHonoClient } from "./binding/create-binding-hono-client";
-import { buildAuthBindingHeaders } from "./binding-headers";
-import { collectSetCookieHeaders, cookieHeaderAfterSetCookie } from "./cookies";
-import type { AuthSession } from "./roles";
-import { getSession } from "./session";
+import {
+	type AuthSession,
+	buildAuthBindingHeaders,
+	collectSetCookieHeaders,
+	cookieHeaderAfterSetCookie,
+	getSession,
+} from "@internal/auth-client";
+import { createBindingAuthWorkerHonoClient } from "@internal/auth-client/binding";
 
 export type EnsureChatSessionResult = {
 	session: AuthSession;
@@ -19,7 +22,7 @@ function requestWithCookieHeader(pageRequest: Request, cookie: string | null): R
 
 /**
  * Ensures the browser has an auth session for chat (anonymous sign-in when logged out).
- * Call from the `/chat` loader so WebSocket attestation can use a stable `user.id`.
+ * Call from chat routes so WebSocket attestation can use a stable `user.id`.
  */
 export async function ensureChatSession(
 	auth: Fetcher,

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -6,6 +6,10 @@
 		".": {
 			"types": "./src/index.ts",
 			"default": "./src/index.ts"
+		},
+		"./binding": {
+			"types": "./src/binding/create-binding-hono-client.ts",
+			"default": "./src/binding/create-binding-hono-client.ts"
 		}
 	},
 	"scripts": {

--- a/packages/auth-client/src/client/create-auth-client.ts
+++ b/packages/auth-client/src/client/create-auth-client.ts
@@ -1,5 +1,4 @@
 import { createBindingAuthWorkerHonoClient } from "../binding/create-binding-hono-client";
-import { type EnsureChatSessionResult, ensureChatSession } from "../chat-session";
 import { type AuthSession, isAdminUser } from "../roles";
 import { getSession } from "../session";
 import { createAccountApi } from "./account-api";
@@ -40,8 +39,6 @@ export function createAuthClient(auth: Fetcher, request: Request, options?: Auth
 				}
 				return session;
 			},
-			ensureChat: (): Promise<EnsureChatSessionResult | null> =>
-				ensureChatSession(auth, request, preloadedSession),
 		},
 		admin: createAdminApi(hono.admin),
 		account: createAccountApi(hono.account),

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -1,5 +1,4 @@
 export * from "./binding-headers";
-export * from "./chat-session";
 export * from "./client";
 export * from "./constants";
 export * from "./cookies";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`ensureChatSession` (anonymous Better Auth sign-in for `/chat` and guest upgrade routes) was living in `@internal/auth-client`, which mixed chat-specific bootstrap logic into the general auth client package.

This PR moves that helper to the web app (`apps/web/app/lib/ensure-chat-session.ts`) and removes it from the auth-client public API (`chat-session.ts` export and unused `auth.session.ensureChat`).

## Direction

- **Auth** (`@internal/auth-client`): sessions, binding clients, admin/account/profile APIs — usable by any feature.
- **Chat** (web routes + `chat-session-context`): depends on auth via `getSession`, binding Hono client, and cookie helpers.

## Changes

- Delete `packages/auth-client/src/chat-session.ts`
- Add `apps/web/app/lib/ensure-chat-session.ts` (same behavior, imports from `@internal/auth-client` + new `@internal/auth-client/binding` subpath)
- Update `chat-session-context.ts` to import locally
- Remove `session.ensureChat` from `createAuthClient`
- Document the new import location in README and `cf-auth-setup` skill

## Notes

`@internal/auth-client/binding` is exported so the web helper can call `POST /sign-in/anonymous` over the service binding without duplicating binding wiring. That subpath is auth infrastructure, not chat-specific.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91f4b0dd-50f3-4321-beeb-a14ed1646900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91f4b0dd-50f3-4321-beeb-a14ed1646900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

